### PR TITLE
Convert State Management to Use Context API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "plugins": ["react", "prettier"],
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2018,
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": true
@@ -17,6 +17,8 @@
     "prettier/prettier": "error",
     "no-unused-vars": ["warn", {
       "args": "none"
-    }]
+    }],
+    "react/prop-types": "off",
+    "no-console": "warn"
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "singleQuote": true,
   "useTabs": false,
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "arrowParens": "avoid",
+  "printWidth": 80
 }

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-
+import UserContextProvider from './components/contexts/userContext.js';
 import Home from './components/Home.jsx';
 import Login from './components/Login.jsx';
 import GetStarted from './components/GetStarted.jsx';
 import Header from './components/layout/Header.jsx';
-
 import './stylesheets/styles.css';
-import UserContextProvider from './components/contexts/userContext.js';
 
 const App = () => {
   return (

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { Button, Typography, SvgIcon } from '@material-ui/core';
 
 import Home from './components/Home.jsx';
 import Login from './components/Login.jsx';
@@ -8,15 +7,18 @@ import GetStarted from './components/GetStarted.jsx';
 import Header from './components/layout/Header.jsx';
 
 import './stylesheets/styles.css';
+import UserContextProvider from './components/contexts/userContext.js';
 
 const App = () => {
   return (
     <React.Fragment>
       <Header />
       <Switch>
-        <Route exact path="/getstarted" component={GetStarted} />
-        <Route exact path="/home" component={Home} />
-        <Route exact path="/" component={Login} />
+        <UserContextProvider>
+          <Route exact path="/getstarted" component={GetStarted} />
+          <Route exact path="/home" component={Home} />
+          <Route exact path="/" component={Login} />
+        </UserContextProvider>
       </Switch>
     </React.Fragment>
   );

--- a/client/components/Age_Company.jsx
+++ b/client/components/Age_Company.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   Table,
   TableBody,
@@ -7,12 +7,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-} from "@material-ui/core";
+} from '@material-ui/core';
 
-export default function Age(props) {
+export default function Age({ ageList, value, view, index }) {
   return (
     <React.Fragment>
-      <div hidden={props.value !== props.index || props.view === 1}>
+      <div hidden={value !== index || view === 1}>
         <div className="data_display_div">
           <TableContainer component={Paper}>
             <Table className="table_displays">
@@ -26,8 +26,8 @@ export default function Age(props) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {props.ageList.map((row) => (
-                  <TableRow key={row.age}>
+                {ageList.map((row, i) => (
+                  <TableRow key={i}>
                     <TableCell>{row.age}</TableCell>
                     <TableCell align="right">{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>

--- a/client/components/Age_Company.jsx
+++ b/client/components/Age_Company.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   Table,
   TableBody,
@@ -8,8 +8,11 @@ import {
   TableHead,
   TableRow,
 } from '@material-ui/core';
+import { UserContext } from './contexts/userContext';
 
-export default function Age({ ageList, value, view, index }) {
+export default function Age({ value, view, index }) {
+  const { ageList } = useContext(UserContext);
+
   return (
     <React.Fragment>
       <div hidden={value !== index || view === 1}>
@@ -32,7 +35,9 @@ export default function Age({ ageList, value, view, index }) {
                     <TableCell align="right">{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>
                     <TableCell align="right">${row.avg_bonus}</TableCell>
-                    <TableCell align="right">${row.avg_stock}</TableCell>
+                    <TableCell align="right">
+                      ${row.avg_stock_options}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/client/components/CompanyComparison.jsx
+++ b/client/components/CompanyComparison.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Container, Tabs, Tab, Box } from '@material-ui/core';
 import Race_Company from './Race_Company.jsx';
 import Age_Company from './Age_Company.jsx';
 import Gender_Company from './Gender_Company.jsx';
 import Total_Company from './Total_Company.jsx';
 
-function CompanyComparison({ view, index }) {
+const CompanyComparison = ({ view, index }) => {
   const [value, setValue] = useState(0);
 
   const changeGraph = (e, newValue) => {
@@ -45,6 +45,6 @@ function CompanyComparison({ view, index }) {
       </Box>
     </React.Fragment>
   );
-}
+};
 
 export default CompanyComparison;

--- a/client/components/CompanyComparison.jsx
+++ b/client/components/CompanyComparison.jsx
@@ -1,12 +1,20 @@
-import React, { useState, useEffect } from "react";
-import { Container, Tabs, Tab, Box, AppBar } from "@material-ui/core";
-import Race_Company from "./Race_Company.jsx";
-import Age_Company from "./Age_Company.jsx";
-import Gender_Company from "./Gender_Company.jsx";
-import Total_Company from "./Total_Company.jsx";
+import React, { useState } from 'react';
+import { Container, Tabs, Tab, Box } from '@material-ui/core';
+import Race_Company from './Race_Company.jsx';
+import Age_Company from './Age_Company.jsx';
+import Gender_Company from './Gender_Company.jsx';
+import Total_Company from './Total_Company.jsx';
 
-function CompanyComparison(props) {
-  const [value, setValue] = useState(0);
+function CompanyComparison({
+  view,
+  index,
+  allNames,
+  aggregateList,
+  raceList,
+  ageList,
+  genderList,
+}) {
+  const [value, setValue] = useState(3);
 
   const changeGraph = (e, newValue) => {
     setValue(newValue);
@@ -15,7 +23,7 @@ function CompanyComparison(props) {
   return (
     <React.Fragment>
       <Container id="company_container">
-        <div hidden={props.view !== props.index} id="company_comparison_div">
+        <div hidden={view !== index} id="company_comparison_div">
           <Tabs
             orientation="vertical"
             variant="scrollable"
@@ -33,35 +41,25 @@ function CompanyComparison(props) {
 
       <Box>
         <Total_Company
-          allNames={props.allNames}
-          aggregateList={props.aggregateList}
-          view={props.view}
+          allNames={allNames}
+          aggregateList={aggregateList}
+          view={view}
           value={value}
           index={0}
         />
       </Box>
       <Box>
-        <Race_Company
-          raceList={props.raceList}
-          view={props.view}
-          value={value}
-          index={1}
-        />
+        <Race_Company raceList={raceList} view={view} value={value} index={1} />
       </Box>
       <Box>
-        <Age_Company
-          view={props.view}
-          value={value}
-          index={2}
-          ageList={props.ageList}
-        />
+        <Age_Company view={view} value={value} index={2} ageList={ageList} />
       </Box>
       <Box>
         <Gender_Company
-          view={props.view}
+          view={view}
           value={value}
           index={3}
-          genderList={props.genderList}
+          genderList={genderList}
         />
       </Box>
     </React.Fragment>

--- a/client/components/CompanyComparison.jsx
+++ b/client/components/CompanyComparison.jsx
@@ -1,20 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Container, Tabs, Tab, Box } from '@material-ui/core';
 import Race_Company from './Race_Company.jsx';
 import Age_Company from './Age_Company.jsx';
 import Gender_Company from './Gender_Company.jsx';
 import Total_Company from './Total_Company.jsx';
 
-function CompanyComparison({
-  view,
-  index,
-  allNames,
-  aggregateList,
-  raceList,
-  ageList,
-  genderList,
-}) {
-  const [value, setValue] = useState(3);
+function CompanyComparison({ view, index }) {
+  const [value, setValue] = useState(0);
 
   const changeGraph = (e, newValue) => {
     setValue(newValue);
@@ -40,27 +32,16 @@ function CompanyComparison({
       </Container>
 
       <Box>
-        <Total_Company
-          allNames={allNames}
-          aggregateList={aggregateList}
-          view={view}
-          value={value}
-          index={0}
-        />
+        <Total_Company view={view} value={value} index={0} />
       </Box>
       <Box>
-        <Race_Company raceList={raceList} view={view} value={value} index={1} />
+        <Race_Company view={view} value={value} index={1} />
       </Box>
       <Box>
-        <Age_Company view={view} value={value} index={2} ageList={ageList} />
+        <Age_Company view={view} value={value} index={2} />
       </Box>
       <Box>
-        <Gender_Company
-          view={view}
-          value={value}
-          index={3}
-          genderList={genderList}
-        />
+        <Gender_Company view={view} value={value} index={3} />
       </Box>
     </React.Fragment>
   );

--- a/client/components/Gender_Company.jsx
+++ b/client/components/Gender_Company.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   Table,
   TableBody,
@@ -7,12 +7,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-} from "@material-ui/core";
+} from '@material-ui/core';
 
-function Gender(props) {
+function Gender({ genderList, value, view, index }) {
   return (
     <React.Fragment>
-      <div hidden={props.value !== props.index || props.view === 1}>
+      <div hidden={value !== index || view === 1}>
         <div className="data_display_div">
           <TableContainer component={Paper}>
             <Table className="table_displays">
@@ -26,8 +26,8 @@ function Gender(props) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {props.genderList.map((row) => (
-                  <TableRow key={row.gender}>
+                {genderList.map((row, i) => (
+                  <TableRow key={i}>
                     <TableCell>{row.gender}</TableCell>
                     <TableCell align="right">{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>

--- a/client/components/Gender_Company.jsx
+++ b/client/components/Gender_Company.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   Table,
   TableBody,
@@ -8,8 +8,10 @@ import {
   TableHead,
   TableRow,
 } from '@material-ui/core';
+import { UserContext } from './contexts/userContext';
 
-function Gender({ genderList, value, view, index }) {
+function Gender({ value, view, index }) {
+  const { genderList } = useContext(UserContext);
   return (
     <React.Fragment>
       <div hidden={value !== index || view === 1}>
@@ -32,7 +34,9 @@ function Gender({ genderList, value, view, index }) {
                     <TableCell align="right">{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>
                     <TableCell align="right">${row.avg_bonus}</TableCell>
-                    <TableCell align="right">${row.avg_stock}</TableCell>
+                    <TableCell align="right">
+                      ${row.avg_stock_options}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/client/components/Home.jsx
+++ b/client/components/Home.jsx
@@ -1,293 +1,43 @@
-import React, { useState, useEffect } from 'react';
-import { Button, AppBar, Tabs, Tab, Typography, Container, withStyles } from '@material-ui/core';
+import React, { useState, useEffect, useContext } from 'react';
+import { Container } from '@material-ui/core';
 import CompanyComparison from './CompanyComparison.jsx';
 import IndividualComparison from './IndividualComparison.jsx';
+import UserHeader from './layout/UserHeader.jsx';
+import { UserContext } from './contexts/userContext.js';
+import ComparisonTabs from './layout/ComparisonTabs.jsx';
 
-const styles = {
-  tabBar: {
-    backgroundColor: '#ffe082',
-    color: 'rgb(102, 102, 102)',
-  },
-};
-function Home(props) {
-  console.log('The props => ', props);
-  // this is the hook that toggles the different comparison views
-  // defaults to company comparison view
+const Home = () => {
+  const { fetchUserData } = useContext(UserContext);
   const [view, setView] = useState(0);
-  const handleComparison = (e, view) => {
+  const [loading, setLoading] = useState(true);
+
+  // Watch tab switching
+  const handleTabSwitch = (e, view) => {
     setView(view);
   };
 
-  // this is name of employee
-  const [name, setName] = useState(null);
-  const [company, setCompany] = useState(null);
-
-  // this is job title
-  const [jobTitle, setJobTitle] = useState(null);
-  // this is sexual orientation
-  const [sexuality, setSexuality] = useState(null);
-  const [age, setAge] = useState(null);
-  const [gender, setGender] = useState();
-  const [race, setRace] = useState();
-  // salary vs hourly employee
-  const [employeeType, setEmployeeType] = useState();
-  // years of experience in field/position
-  const [yrsExperience, setYrsExperience] = useState();
-  // years at current company
-  const [yrsCompany, setYrsCompany] = useState();
-  const [baseSalary, setBaseSalary] = useState();
-  const [annualBonus, setAnnualBonus] = useState();
-  // total invested and uninvested
-  const [stockOptions, setStockOptions] = useState();
-  const [signingBonus, setSigningBonus] = useState();
-  const [ftStatus, setFtStatus] = useState();
-
-  // this section is for individual comparison component
-  const [allNames, setAllNames] = useState([]);
-  const [allSexes, setAllSexes] = useState([]);
-  const [allGenders, setAllGenders] = useState([]);
-  const [allAges, setAllAges] = useState([]);
-  const [allTypes, setAllTypes] = useState([]);
-  const [allYrsExperience, setAllYrsExperience] = useState([]);
-  const [allYrsCompany, setAllYrsCompany] = useState([]);
-  const [allBaseSalary, setAllBaseSalary] = useState([]);
-  const [allAnnualBonus, setAllAnnualBonus] = useState([]);
-  const [allStockOptions, setAllStockOptions] = useState([]);
-  const [allSigningBonuses, setAllSigningBonuses] = useState([]);
-  const [allFtStatuses, setAllFtStatuses] = useState([]);
-  const [raceList, setRaceList] = useState([]);
-  const [genderList, setGenderList] = useState([]);
-  const [ageList, setAgeList] = useState([]);
-  const [aggregateList, setAggregateList] = useState([]);
-
-  // state for whether fetch call is finished
-  const [loading, setLoading] = useState(false);
-
-  // used for prop drilling into child components
-  const employeesNames = [];
-  const employeesSexuality = [];
-  const employeesGender = [];
-  const employeesAge = [];
-  const employeesType = [];
-  const employeesYrsExperience = [];
-  const employeesYrsCompany = [];
-  const employeesBaseSalary = [];
-  const employeesAnnualBonus = [];
-  const employeesStockOptions = [];
-  const employeesSigningBonus = [];
-  const employeesFtStatus = [];
-  const raceAvg = [];
-  const genderAvg = [];
-  const ageAvg = [];
-  const aggregateAvg = [];
-
+  // Fetch user data on mount
   useEffect(() => {
-    // let user_linkedin_id = document.cookie;
-    // user_linkedin_id = user_linkedin_id
-    //   .split('; ')
-    //   .find(row => row.startsWith('userId'))
-    //   .split('=')[1];
-
-    setLoading(true);
-
-    // provide user_linkedin_id in req params
-    fetch(`/api/company`)
-      .then(res => res.json())
-      .then(data => {
-        // with this data, setState for each hook and prop drill to appropriate components
-        console.log('data from fetch', data);
-        const current = data.currentUser;
-
-        // setting state for current logged in user
-        setName(current.name);
-        setCompany(current.linkedin_id);
-        setJobTitle(current.job_title);
-        setSexuality(current.sexuality);
-        setAge(current.age);
-        setGender(current.gender);
-        setRace(current.race);
-        setEmployeeType(current.employee_type);
-        setYrsExperience(current.years_of_experience);
-        setYrsCompany(current.years_at_company);
-        setBaseSalary(current.base_salary);
-        setAnnualBonus(current.annual_bonus);
-        setStockOptions(current.stock_options);
-        setSigningBonus(current.signing_bonus);
-        setFtStatus(current.full_time_status);
-
-        //grabbing race averages
-        const raceList = data.raceStats;
-        raceList.forEach(race => {
-          raceAvg.push({
-            race: race.race,
-            avg_bonus: race.avg_bonus,
-            avg_salary: race.avg_salary,
-            avg_stock: race.avg_stock_options,
-            count: race.count,
-          });
-        });
-        setRaceList(raceAvg);
-
-        // grabbing gender averages
-        const genderList = data.genderStats;
-        genderList.forEach(gender => {
-          genderAvg.push({
-            gender: gender.gender,
-            avg_bonus: gender.avg_bonus,
-            avg_salary: gender.avg_salary,
-            avg_stock: gender.avg_stock_options,
-            count: gender.count,
-          });
-        });
-        setGenderList(genderAvg);
-
-        //grabbing age averages
-        const ageList = data.ageStats;
-        ageList.forEach(age => {
-          ageAvg.push({
-            age: age.age,
-            avg_salary: age.avg_salary,
-            avg_bonus: age.avg_bonus,
-            avg_stock: age.avg_stock_options,
-            count: age.count,
-          });
-        });
-        setAgeList(ageAvg);
-
-        // calculating values for aggregate view
-        const aggregateList = data.jobStats;
-        aggregateList.forEach(item => {
-          aggregateAvg.push({
-            avg_salary: item.avg_salary,
-            avg_bonus: item.avg_bonus,
-            avg_stock: item.avg_stock_options,
-            title: item.job_title,
-            count: item.count,
-          });
-        });
-        setAggregateList(aggregateAvg);
-
-        // setting state for individual comparisons
-        const list = data.companyData;
-        list.forEach(employee => {
-          employeesNames.push(employee.name);
-          employeesAge.push(employee.age);
-          employeesGender.push(employee.gender);
-          employeesSexuality.push(employee.sexuality);
-          employeesType.push(employee.employee_type);
-          employeesYrsExperience.push(employee.years_of_experience);
-          employeesYrsCompany.push(employee.years_at_company);
-          employeesBaseSalary.push(employee.base_salary);
-          employeesAnnualBonus.push(employee.annual_bonus);
-          employeesStockOptions.push(employee.stock_options);
-          employeesSigningBonus.push(employee.signing_bonus);
-          employeesFtStatus.push(employee.full_time_status);
-        });
-        setAllNames(employeesNames);
-        setAllGenders(employeesGender);
-        setAllAges(employeesAge);
-        setAllSexes(employeesSexuality);
-        setAllTypes(employeesType);
-        setAllYrsExperience(employeesYrsExperience);
-        setAllYrsCompany(employeesYrsCompany);
-        setAllBaseSalary(employeesBaseSalary);
-        setAllFtStatuses(employeesFtStatus);
-
-        // after finishing this execution, set loading to false
-        setLoading(false);
-      })
-      .catch(err => console.log(err));
+    fetchUserData();
+    setLoading(false);
   }, []);
 
-  const { classes } = props;
-  console.log('PROPS => ', props);
-  console.log('what are classes:', classes);
   return (
     <React.Fragment>
-      {/* Header STARTS here */}
-      {loading ? null : (
-        <div className="current_user_header">
-          <h2 id="current_user_name">Hello {name}</h2>
-          <label id="current_user_label">
-            {jobTitle} at {company}
-          </label>
-        </div>
-      )}
-      {/* Header ENDS here */}
-
-      {/* Bar that has the individual comparisons */}
-      <Container id="comparison_tabs">
-        <AppBar className={classes.tabBar} id="company_individual_toggle" position="static">
-          <Tabs view={view} onChange={handleComparison} centered>
-            <Tab label="Company Wide Comparison" />
-            <Tab label="Individual Comparison" />
-          </Tabs>
-        </AppBar>
-      </Container>
-      {/* End of bar */}
-
-      {/* CURRENT BUG, since there is an error in the fetch req-res, the loading state never hits the end of the useEffect hook and loading is never flipped to false*/}
+      <UserHeader />
+      <ComparisonTabs view={view} handleTabSwitch={handleTabSwitch} />
       {loading ? (
         <h2 className="current_user_header">Loading Data...</h2>
       ) : (
         <div id="tables_div">
           <Container>
-            <CompanyComparison
-              view={view}
-              index={0}
-              name={name}
-              company={company}
-              jobTitle={jobTitle}
-              sexuality={sexuality}
-              age={age}
-              gender={gender}
-              race={race}
-              employeeType={employeeType}
-              yrsExperience={yrsExperience}
-              yrsCompany={yrsCompany}
-              baseSalary={baseSalary}
-              annualBonus={annualBonus}
-              stockOptions={stockOptions}
-              signingBonus={signingBonus}
-              ftStatus={ftStatus}
-              raceList={raceList}
-              genderList={genderList}
-              ageList={ageList}
-              aggregateList={aggregateList}
-              allNames={allNames}
-            />
-            <IndividualComparison
-              view={view}
-              index={1}
-              name={name}
-              company={company}
-              jobTitle={jobTitle}
-              sexuality={sexuality}
-              age={age}
-              gender={gender}
-              race={race}
-              employeeType={employeeType}
-              yrsExperience={yrsExperience}
-              yrsCompany={yrsCompany}
-              baseSalary={baseSalary}
-              annualBonus={annualBonus}
-              stockOptions={stockOptions}
-              signingBonus={signingBonus}
-              ftStatus={ftStatus}
-              allNames={allNames}
-              allGenders={allGenders}
-              allAges={allAges}
-              allSexes={allSexes}
-              allTypes={allTypes}
-              allYrsExperience={allYrsExperience}
-              allYrsCompany={allYrsCompany}
-              allBaseSalary={allBaseSalary}
-            />
+            <CompanyComparison view={view} index={0} />
+            <IndividualComparison view={view} index={1} />
           </Container>
         </div>
       )}
     </React.Fragment>
   );
-}
+};
 
-export default withStyles(styles)(Home);
+export default Home;

--- a/client/components/IndividualComparison.jsx
+++ b/client/components/IndividualComparison.jsx
@@ -11,10 +11,9 @@ import {
 } from '@material-ui/core';
 import { UserContext } from './contexts/userContext';
 
-function IndividualComparison({ view, index }) {
-  // need to write logic that loops through the data we get back from the fetch request and renders
-  // all the employee data who work at the same company with the same title
+const IndividualComparison = ({ view, index }) => {
   const { companyList } = useContext(UserContext);
+
   return (
     <React.Fragment>
       <Container>
@@ -33,6 +32,7 @@ function IndividualComparison({ view, index }) {
                   <TableCell align="right">Years of Experience</TableCell>
                 </TableRow>
               </TableHead>
+
               <TableBody>
                 {companyList.map(
                   (
@@ -67,6 +67,6 @@ function IndividualComparison({ view, index }) {
       </Container>
     </React.Fragment>
   );
-}
+};
 
 export default IndividualComparison;

--- a/client/components/IndividualComparison.jsx
+++ b/client/components/IndividualComparison.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   Container,
   Table,
@@ -9,22 +9,12 @@ import {
   TableHead,
   TableRow,
 } from '@material-ui/core';
+import { UserContext } from './contexts/userContext';
 
-function IndividualComparison({
-  view,
-  index,
-  allNames,
-  allAges,
-  allBaseSalary,
-  allGenders,
-  allTypes,
-  allSexes,
-  allYrsCompany,
-  allYrsExperience,
-}) {
+function IndividualComparison({ view, index }) {
   // need to write logic that loops through the data we get back from the fetch request and renders
   // all the employee data who work at the same company with the same title
-
+  const { companyList } = useContext(UserContext);
   return (
     <React.Fragment>
       <Container>
@@ -44,20 +34,32 @@ function IndividualComparison({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {allNames.map((key, i) => {
-                  return (
+                {companyList.map(
+                  (
+                    {
+                      name,
+                      age,
+                      base_salary,
+                      gender,
+                      job_title,
+                      sexuality,
+                      years_at_company,
+                      years_of_experience,
+                    },
+                    i
+                  ) => (
                     <TableRow key={i}>
-                      <TableCell>{key}</TableCell>
-                      <TableCell align="right">{allAges[i]}</TableCell>
-                      <TableCell align="right">${allBaseSalary[i]}</TableCell>
-                      <TableCell align="right">{allGenders[i]}</TableCell>
-                      <TableCell align="right">{allTypes[i]}</TableCell>
-                      <TableCell align="right">{allSexes[i]}</TableCell>
-                      <TableCell align="right">{allYrsCompany[i]}</TableCell>
-                      <TableCell align="right">{allYrsExperience[i]}</TableCell>
+                      <TableCell>{name}</TableCell>
+                      <TableCell align="right">{age}</TableCell>
+                      <TableCell align="right">${base_salary}</TableCell>
+                      <TableCell align="right">{gender}</TableCell>
+                      <TableCell align="right">{job_title}</TableCell>
+                      <TableCell align="right">{sexuality}</TableCell>
+                      <TableCell align="right">{years_at_company}</TableCell>
+                      <TableCell align="right">{years_of_experience}</TableCell>
                     </TableRow>
-                  );
-                })}
+                  )
+                )}
               </TableBody>
             </Table>
           </TableContainer>

--- a/client/components/IndividualComparison.jsx
+++ b/client/components/IndividualComparison.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from 'react';
 import {
   Container,
   Table,
@@ -8,36 +8,27 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-} from "@material-ui/core";
+} from '@material-ui/core';
 
-function IndividualComparison(props) {
+function IndividualComparison({
+  view,
+  index,
+  allNames,
+  allAges,
+  allBaseSalary,
+  allGenders,
+  allTypes,
+  allSexes,
+  allYrsCompany,
+  allYrsExperience,
+}) {
   // need to write logic that loops through the data we get back from the fetch request and renders
   // all the employee data who work at the same company with the same title
-
-  const [name, setName] = useState(props.name);
-  const [company, setCompany] = useState(props.company);
-  const [jobTitle, setJobTitle] = useState(props.jobTitle);
-  const [sexuality, setSexuality] = useState(null);
-  const [age, setAge] = useState(null);
-  const [gender, setGender] = useState();
-  const [race, setRace] = useState();
-  // salary vs hourly employee
-  const [employeeType, setEmployeeType] = useState();
-  // years of experience in field/position
-  const [yrsExperience, setYrsExperience] = useState();
-  // years at current company
-  const [yrsCompany, setYrsCompany] = useState();
-  const [baseSalary, setBaseSalary] = useState();
-  const [annualBonus, setAnnualBonus] = useState();
-  // total invested and uninvested
-  const [stockOptions, setStockOptions] = useState();
-  const [signingBonus, setSigningBonus] = useState();
-  const [ftStatus, setFtStatus] = useState();
 
   return (
     <React.Fragment>
       <Container>
-        <div hidden={props.view !== props.index} id="individual_comparison_div">
+        <div hidden={view !== index} id="individual_comparison_div">
           <TableContainer component={Paper}>
             <Table>
               <TableHead>
@@ -53,23 +44,17 @@ function IndividualComparison(props) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {props.allNames.map((key, i) => {
+                {allNames.map((key, i) => {
                   return (
-                    <TableRow>
+                    <TableRow key={i}>
                       <TableCell>{key}</TableCell>
-                      <TableCell align="right">{props.allAges[i]}</TableCell>
-                      <TableCell align="right">
-                        ${props.allBaseSalary[i]}
-                      </TableCell>
-                      <TableCell align="right">{props.allGenders[i]}</TableCell>
-                      <TableCell align="right">{props.allTypes[i]}</TableCell>
-                      <TableCell align="right">{props.allSexes[i]}</TableCell>
-                      <TableCell align="right">
-                        {props.allYrsCompany[i]}
-                      </TableCell>
-                      <TableCell align="right">
-                        {props.allYrsExperience[i]}
-                      </TableCell>
+                      <TableCell align="right">{allAges[i]}</TableCell>
+                      <TableCell align="right">${allBaseSalary[i]}</TableCell>
+                      <TableCell align="right">{allGenders[i]}</TableCell>
+                      <TableCell align="right">{allTypes[i]}</TableCell>
+                      <TableCell align="right">{allSexes[i]}</TableCell>
+                      <TableCell align="right">{allYrsCompany[i]}</TableCell>
+                      <TableCell align="right">{allYrsExperience[i]}</TableCell>
                     </TableRow>
                   );
                 })}

--- a/client/components/Race_Company.jsx
+++ b/client/components/Race_Company.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   Table,
   TableBody,
@@ -7,14 +7,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-} from "@material-ui/core";
+} from '@material-ui/core';
 
-function Race(props) {
-  const sliced = props.raceList;
-  console.log(sliced);
+function Race({ raceList, value, view, index }) {
   return (
     <React.Fragment>
-      <div hidden={props.value !== props.index || props.view === 1}>
+      <div hidden={value !== index || view === 1}>
         <div className="data_display_div">
           <TableContainer component={Paper}>
             <Table className="table_displays">
@@ -29,8 +27,8 @@ function Race(props) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {sliced.map((row) => (
-                  <TableRow key={row.race}>
+                {raceList.map((row, i) => (
+                  <TableRow key={i}>
                     <TableCell>{row.race}</TableCell>
                     <TableCell align="right">{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>

--- a/client/components/Race_Company.jsx
+++ b/client/components/Race_Company.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   Table,
   TableBody,
@@ -8,8 +8,10 @@ import {
   TableHead,
   TableRow,
 } from '@material-ui/core';
+import { UserContext } from './contexts/userContext';
 
-function Race({ raceList, value, view, index }) {
+function Race({ value, view, index }) {
+  const { raceList } = useContext(UserContext);
   return (
     <React.Fragment>
       <div hidden={value !== index || view === 1}>
@@ -33,7 +35,9 @@ function Race({ raceList, value, view, index }) {
                     <TableCell align="right">{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>
                     <TableCell align="right">${row.avg_bonus}</TableCell>
-                    <TableCell align="right">${row.avg_stock}</TableCell>
+                    <TableCell align="right">
+                      ${row.avg_stock_options}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/client/components/TitleCount.jsx
+++ b/client/components/TitleCount.jsx
@@ -4,8 +4,8 @@ const TitleCount = ({ titles }) => {
   return (
     <React.Fragment>
       {titles
-        ? titles.map(({ job_title, total }) => (
-            <p>
+        ? titles.map(({ job_title, total }, i) => (
+            <p key={i}>
               {job_title}: {total} submissions
             </p>
           ))

--- a/client/components/Total_Company.jsx
+++ b/client/components/Total_Company.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   Table,
   TableBody,
@@ -7,12 +7,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-} from "@material-ui/core";
+} from '@material-ui/core';
 
-function Total(props) {
+function Total({ aggregateList, value, view, index }) {
   return (
     <React.Fragment>
-      <div hidden={props.value !== props.index || props.view === 1}>
+      <div hidden={value !== index || view === 1}>
         <div className="data_display_div">
           <TableContainer component={Paper}>
             <Table className="table_displays">
@@ -25,8 +25,8 @@ function Total(props) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {props.aggregateList.map((row) => (
-                  <TableRow>
+                {aggregateList.map((row, i) => (
+                  <TableRow key={i}>
                     <TableCell>{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>
                     <TableCell align="right">${row.avg_bonus}</TableCell>

--- a/client/components/Total_Company.jsx
+++ b/client/components/Total_Company.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   Table,
   TableBody,
@@ -8,8 +8,10 @@ import {
   TableHead,
   TableRow,
 } from '@material-ui/core';
+import { UserContext } from './contexts/userContext';
 
-function Total({ aggregateList, value, view, index }) {
+function Total({ value, view, index }) {
+  const { aggregateList } = useContext(UserContext);
   return (
     <React.Fragment>
       <div hidden={value !== index || view === 1}>
@@ -30,7 +32,9 @@ function Total({ aggregateList, value, view, index }) {
                     <TableCell>{row.count}</TableCell>
                     <TableCell align="right">${row.avg_salary}</TableCell>
                     <TableCell align="right">${row.avg_bonus}</TableCell>
-                    <TableCell align="right">${row.avg_stock}</TableCell>
+                    <TableCell align="right">
+                      ${row.avg_stock_options}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/client/components/contexts/userContext.js
+++ b/client/components/contexts/userContext.js
@@ -1,0 +1,64 @@
+import React, { createContext, useState } from 'react';
+
+export const UserContext = createContext();
+
+const UserContextProvider = props => {
+  const [user, setUser] = useState({
+    name: '',
+    jobTitle: '',
+    company: '',
+  });
+
+  const [raceList, setRace] = useState([]);
+  const [genderList, setGender] = useState([]);
+  const [ageList, setAge] = useState([]);
+  const [aggregateList, setAggregate] = useState([]);
+  const [companyList, setCompany] = useState([]);
+
+  const fetchUserData = () => {
+    fetch('/api/company')
+      .then(res => res.json())
+      .then(res => {
+        const {
+          currentUser,
+          raceStats,
+          genderStats,
+          ageStats,
+          jobStats,
+          companyData,
+        } = res;
+
+        const { name, linkedin_id, job_title } = currentUser;
+        setUser(state => ({
+          ...state,
+          name: name,
+          company: linkedin_id,
+          jobTitle: job_title,
+        }));
+
+        setRace(raceStats);
+        setGender(genderStats);
+        setAge(ageStats);
+        setAggregate(jobStats);
+        setCompany(companyData);
+      });
+  };
+
+  return (
+    <UserContext.Provider
+      value={{
+        fetchUserData,
+        user,
+        raceList,
+        genderList,
+        ageList,
+        aggregateList,
+        companyList,
+      }}
+    >
+      {props.children}
+    </UserContext.Provider>
+  );
+};
+
+export default UserContextProvider;

--- a/client/components/contexts/userContext.js
+++ b/client/components/contexts/userContext.js
@@ -3,16 +3,20 @@ import React, { createContext, useState } from 'react';
 export const UserContext = createContext();
 
 const UserContextProvider = props => {
+  // User state
   const [user, setUser] = useState({
     name: '',
     jobTitle: '',
     company: '',
   });
 
+  // Stats state
   const [raceList, setRace] = useState([]);
   const [genderList, setGender] = useState([]);
   const [ageList, setAge] = useState([]);
   const [aggregateList, setAggregate] = useState([]);
+
+  // Company wide state
   const [companyList, setCompany] = useState([]);
 
   const fetchUserData = () => {
@@ -28,6 +32,7 @@ const UserContextProvider = props => {
           companyData,
         } = res;
 
+        // Set user state
         const { name, linkedin_id, job_title } = currentUser;
         setUser(state => ({
           ...state,
@@ -36,6 +41,7 @@ const UserContextProvider = props => {
           jobTitle: job_title,
         }));
 
+        // Set stats and company wide state
         setRace(raceStats);
         setGender(genderStats);
         setAge(ageStats);

--- a/client/components/layout/ComparisonTabs.jsx
+++ b/client/components/layout/ComparisonTabs.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Container, AppBar, Tabs, Tab } from '@material-ui/core';
+
+const ComparisonTabs = ({ view, handleTabSwitch }) => {
+  return (
+    <Container id="comparison_tabs">
+      <AppBar
+        style={tabBarStyle}
+        id="company_individual_toggle"
+        position="static"
+      >
+        <Tabs view={view} onChange={handleTabSwitch} centered>
+          <Tab label="Company Wide Comparison" />
+          <Tab label="Individual Comparison" />
+        </Tabs>
+      </AppBar>
+    </Container>
+  );
+};
+
+// Styles
+const tabBarStyle = {
+  backgroundColor: '#ffe082',
+  color: 'rgb(102, 102, 102)',
+};
+
+export default ComparisonTabs;

--- a/client/components/layout/UserHeader.jsx
+++ b/client/components/layout/UserHeader.jsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { UserContext } from '../contexts/userContext';
+
+const UserHeader = () => {
+  const { user } = useContext(UserContext);
+  const { name, jobTitle, company } = user;
+
+  return (
+    <div className="current_user_header">
+      <h2 id="current_user_name">Hello {name}</h2>
+      <label id="current_user_label">
+        {jobTitle} at {company}
+      </label>
+    </div>
+  );
+};
+
+export default UserHeader;


### PR DESCRIPTION
### Setup React Context
- Created the User Context Provider to enable components to have access to state without having to prop drill at all

### Converted everything from local state
- ***Home.jsx:*** removed everything from the useEffect Hook and relocated state to the User Context
- ***Individual Comparison and Company Comparison*** removed the properties that were being passed down from Home.jsx to children components
- ***_Company***: Gave components direct access to company wide and race/gender/age/job statistics

### Refactored and Cleanup Code
- Created components for tabs and headers for more modular code
- Removed several unused data that was being returned from the fetch request to /api/company endpoint